### PR TITLE
updated shin megami tensei link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Thanks to everyone who helped, Listed [Here!](https://github.com/SamidyFR/Game-D
 
 ### **NOTES:**
 
-- Some decomps are still unfinished and they need to be checked before downloading.  
+- Some decomps are still unfinished and they need to be checked before downloading.
 - The list is a Work in Progress (WIP). Still a bunch missing. If you want to help by fixing spelling mistakes, duplicates or just add more game decomps, read the [Contributing Guide!](https://github.com/SamidyFR/Game-Decompilations/blob/main/CONTRIBUTING.md)
 - **TIP: Use Ctrl+F To search for a Game decomp! This is listed in alphabetical order but the list is LONG, Which is why we recommend Ctrl+F**
 
@@ -386,7 +386,7 @@ Like what you see? [⭐ The Github Repo!](https://github.com/SamidyFR/Game-Decom
 - [Shadow Hearts](https://git.sr.ht/~benoitren/shadowheartsdecompilation)
 - [Shadow of the Colossus](https://github.com/Fantaskink/SOTC)
 - [Shadowgate 64](https://github.com/rainchus/shadowgate64)
-- [Shin Megami Tensei](https://github.com/thecommandochicken/smt-decomp)
+- [Shin Megami Tensei](https://codeberg.org/Chickenzes/smt-decomp)
 - [Shining Force CD](https://github.com/ShiningForceCentral/SFCDDISASM)
 - [Shortline railroad](https://github.com/konovalov-aleks/reSL)
 - [Silent Hill 3](https://github.com/dreamingmoths/memory-of-alessa)

--- a/index.html
+++ b/index.html
@@ -424,7 +424,7 @@ Decompilations
 <li><a href="https://git.sr.ht/~benoitren/shadowheartsdecompilation">Shadow Hearts</a></li>
 <li><a href="https://github.com/Fantaskink/SOTC">Shadow of the Colossus</a></li>
 <li><a href="https://github.com/rainchus/shadowgate64">Shadowgate 64</a></li>
-<li><a href="https://github.com/thecommandochicken/smt-decomp">Shin Megami Tensei</a></li>
+<li><a href="https://codeberg.org/Chickenzes/smt-decomp">Shin Megami Tensei</a></li>
 <li><a href="https://github.com/ShiningForceCentral/SFCDDISASM">Shining Force CD</a></li>
 <li><a href="https://github.com/konovalov-aleks/reSL">Shortline railroad</a></li>
 <li><a href="https://github.com/dreamingmoths/memory-of-alessa">Silent Hill 3</a></li>
@@ -652,7 +652,5 @@ function microfuzz(input, text) {
   return false;
 }
 </script>
-    
+
 </body></html>
-
-


### PR DESCRIPTION
my text editor automatically deletes trailing whitespace and trailing newlines, that's why a few more lines are edited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated decompilation project link to new source location.

* **Chores**
  * Minor formatting and whitespace adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->